### PR TITLE
Add ~/.codex file-based authentication for Codex CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,10 @@ Installed via the [native installer](https://claude.ai/install.sh) (npm is depre
 
 ### Codex
 
-Installed via `npm install -g @openai/codex`. Authenticates through `OPENAI_API_KEY`.
+Installed via `npm install -g @openai/codex`. Two authentication methods are supported:
+
+- **API key**: set `OPENAI_API_KEY` in your environment or in `~/.config/ai-sandbox/env`
+- **OAuth (ChatGPT login)**: run `codex login` on the host first, then `~/.codex/` is automatically mounted into the container (contains `auth.json` and `config.toml`)
 
 ### Cursor Agent
 
@@ -129,6 +132,7 @@ Built on **Fedora 43** and includes: Node.js, npm, Python 3.14 (default), Python
 ```
 
 - **Claude**: if `~/.claude` exists on the host, it is bind-mounted into the container for OAuth session persistence.
+- **Codex**: if `~/.codex` exists on the host, it is bind-mounted into the container for OAuth/cached login persistence.
 - **Cursor**: if `~/.cursor` exists on the host, it is bind-mounted into the container so `cursor-agent` has access to its project state and config.
 
 ## License

--- a/ai-sandbox
+++ b/ai-sandbox
@@ -135,6 +135,8 @@ fi
 if [[ -z "${!API_KEY_VAR:-}" ]]; then
     if [[ "$AGENT" == "claude" && -d "${HOME}/.claude" ]]; then
         echo -e "${CYAN}Using OAuth session from ~/.claude${NC}"
+    elif [[ "$AGENT" == "codex" && -d "${HOME}/.codex" ]]; then
+        echo -e "${CYAN}Using cached login from ~/.codex${NC}"
     elif [[ "$AGENT" == "cursor" && -f "${HOME}/.config/cursor/auth.json" ]]; then
         echo -e "${CYAN}Using JWT auth from ~/.config/cursor/auth.json${NC}"
     else
@@ -143,6 +145,8 @@ if [[ -z "${!API_KEY_VAR:-}" ]]; then
         echo "Or create it in ${ENV_FILE}"
         if [[ "$AGENT" == "claude" ]]; then
             echo "Or run 'claude login' on the host first to create ~/.claude/"
+        elif [[ "$AGENT" == "codex" ]]; then
+            echo "Or run 'codex login' on the host first to create ~/.codex/"
         fi
         echo ""
         read -rp "Do you want to continue anyway? [y/N] " confirm
@@ -217,6 +221,13 @@ if [[ "$AGENT" == "cursor" ]]; then
     # auth.json: ro (contains JWT tokens, no need to write)
     if [[ -f "${HOME}/.config/cursor/auth.json" ]]; then
         CMD+=(-v "${HOME}/.config/cursor/auth.json:/home/agent/.config/cursor/auth.json:ro,Z")
+    fi
+fi
+
+# === CODEX CONFIG: mount ~/.codex for OAuth + settings ===
+if [[ "$AGENT" == "codex" ]]; then
+    if [[ -d "${HOME}/.codex" ]]; then
+        CMD+=(-v "${HOME}/.codex:/home/agent/.codex:Z")
     fi
 fi
 

--- a/codex/Containerfile
+++ b/codex/Containerfile
@@ -1,13 +1,16 @@
 # =============================================================================
 # OpenAI Codex CLI - sandboxed container
-# Auth: OPENAI_API_KEY env var
+# Auth: OPENAI_API_KEY env var or OAuth/cached login via ~/.codex/
 # =============================================================================
 FROM localhost/agent-base:latest
 
 USER root
 RUN npm install -g @openai/codex
 
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod 755 /usr/local/bin/entrypoint.sh
+
 USER agent
 WORKDIR /workspace
 
-ENTRYPOINT ["codex"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/codex/entrypoint.sh
+++ b/codex/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Prepare home directories on tmpfs before starting Codex CLI
+mkdir -p ~/.cache ~/.config
+exec codex "$@"


### PR DESCRIPTION
Same pattern already used for Claude (~/.claude) and Cursor (~/.cursor): mount the host's ~/.codex directory into the container so OAuth/cached login tokens are available without requiring OPENAI_API_KEY.