### PR TITLE
Add bpf/ directory scaffolding for LSM command blocker

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# another-ai-sandbox
+#
+# Build system for BPF program and userspace loader.
+# Targets: vmlinux.h, block_commands.bpf.o, block_commands.skel.h, loader,
+#          clean, install.

--- a/bpf/README.md
+++ b/bpf/README.md
@@ -1,0 +1,25 @@
+# BPF LSM Command Blocker
+
+## Overview
+
+TODO
+
+## Kernel Requirements
+
+TODO
+
+## Build Dependencies
+
+TODO
+
+## Build
+
+TODO
+
+## Usage
+
+TODO
+
+## How It Works
+
+TODO

--- a/bpf/block_commands.bpf.c
+++ b/bpf/block_commands.bpf.c
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// another-ai-sandbox
+//
+// BPF LSM program that hooks into bprm_check_security to block execution of
+// configured commands, scoped to a specific cgroup v2. Populated via userspace
+// loader.

--- a/bpf/block_commands.h
+++ b/bpf/block_commands.h
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// another-ai-sandbox
+//
+// Shared structures between BPF program and userspace loader: blocked_cmd_key_t,
+// map definitions, constants.

--- a/bpf/config.h
+++ b/bpf/config.h
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// another-ai-sandbox
+//
+// Configuration defines: MAX_BIN_LEN, MAX_ARG_LEN, MAX_BLOCKED_CMDS.
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#define MAX_BIN_LEN 64
+#define MAX_ARG_LEN 64
+#define MAX_BLOCKED_CMDS 64
+
+#endif

--- a/bpf/loader.c
+++ b/bpf/loader.c
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// another-ai-sandbox
+//
+// Userspace loader (libbpf): loads the BPF program, populates blocked_cmds and
+// target_cgroup maps, attaches to LSM hook, handles cleanup on SIGINT/SIGTERM.


### PR DESCRIPTION
Introduce placeholder files for the BPF LSM command blocker component: block_commands.bpf.c, block_commands.h, config.h, loader.c, Makefile, and README.md. Only config.h contains actual defines (MAX_BIN_LEN, MAX_ARG_LEN, MAX_BLOCKED_CMDS); all other files are header-only stubs. Closes #9