### PR TITLE
Implement Makefile for BPF program and userspace loader build chain

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -4,3 +4,45 @@
 # Build system for BPF program and userspace loader.
 # Targets: vmlinux.h, block_commands.bpf.o, block_commands.skel.h, loader,
 #          clean, install.
+#
+# Build dependencies:
+#   Fedora: dnf install clang llvm libbpf-devel bpftool elfutils-libelf-devel zlib-devel
+#   Gentoo: emerge -av sys-devel/clang sys-devel/llvm dev-libs/libbpf sys-apps/bpftool dev-libs/elfutils sys-libs/zlib
+
+CLANG      ?= clang
+LLC        ?= llc
+BPFTOOL    ?= bpftool
+CC         ?= gcc
+ARCH       := $(shell uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/')
+VMLINUX    := /sys/kernel/btf/vmlinux
+PREFIX     ?= /usr/local
+DESTDIR    ?=
+
+.PHONY: all clean install
+
+all: loader
+
+vmlinux.h:
+	$(BPFTOOL) btf dump file $(VMLINUX) format c > vmlinux.h
+
+block_commands.bpf.o: block_commands.bpf.c vmlinux.h config.h
+	$(CLANG) -g -O2 -target bpf -D__TARGET_ARCH_$(ARCH) \
+		-I. \
+		-c block_commands.bpf.c \
+		-o block_commands.bpf.o
+
+block_commands.skel.h: block_commands.bpf.o
+	$(BPFTOOL) gen skeleton block_commands.bpf.o > block_commands.skel.h
+
+loader: loader.c block_commands.skel.h block_commands.h config.h
+	$(CC) -Wall -Wextra -O2 \
+		-I. \
+		-o loader loader.c \
+		-lbpf -lelf -lz
+
+clean:
+	rm -f vmlinux.h block_commands.bpf.o block_commands.skel.h loader
+
+install: loader
+	install -d $(DESTDIR)$(PREFIX)/bin
+	install -m 755 loader $(DESTDIR)$(PREFIX)/bin/bpf-sandbox-loader


### PR DESCRIPTION
Replace the placeholder Makefile with a fully functional build system that generates vmlinux.h from kernel BTF, compiles the BPF object, generates the libbpf skeleton header, and links the userspace loader against libbpf/elf/zlib. Includes clean, install targets and build dependency instructions for Fedora and Gentoo.
Closes #12