### PR TITLE
Add end-to-end tests and documentation for BPF command blocker

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,21 @@ Rootless Podman containers to run AI coding agents (Claude Code, Codex, Cursor A
 ai-sandbox/
 ├── base/
 │   └── Containerfile          # Base image (Fedora 43, Node.js, Python, Git, ripgrep, …)
+├── bpf/
+│   ├── block_commands.bpf.c   # BPF LSM program (hooks bprm_check_security)
+│   ├── block_commands.h       # Shared structures (blocked_cmd_key)
+│   ├── config.h               # Configuration defines (MAX_BIN_LEN, etc.)
+│   ├── loader.c               # Userspace loader (libbpf skeleton)
+│   ├── Makefile               # Build system for BPF program and loader
+│   └── README.md              # BPF component documentation
 ├── claude-code/
 │   └── Containerfile          # Claude Code (native installer + npm fallback)
 ├── codex/
 │   └── Containerfile          # OpenAI Codex CLI
 ├── cursor-agent/
 │   └── Containerfile          # Cursor Agent CLI (installed to /opt to survive tmpfs)
+├── test/
+│   └── test_bpf_blocker.sh   # End-to-end tests for BPF command blocker
 ├── build.sh                   # Build script for images
 ├── ai-sandbox                 # Wrapper to start agents
 ├── LICENSE                    # GPLv3
@@ -68,6 +77,7 @@ Every container is launched with the following hardening measures:
 | `--tmpfs /tmp`                | Temporary writable area, destroyed at session end          |
 | `--mount type=tmpfs,dst=/home/agent` | Agent home on tmpfs (mode 0755), destroyed at session end |
 | Bind mount only `/workspace`  | Agent sees ONLY the project directory                      |
+| BPF LSM command blocker       | Blocks specific commands (e.g. git push) inside the container via eBPF |
 
 ## Usage
 
@@ -77,6 +87,7 @@ ai-sandbox <agent> [directory] [-- extra args for the agent]
 Agents:   claude | codex | cursor
 
 Options:
+  -b, --block-cmd <b:a>   Block command inside container (repeatable, e.g. "git:push")
   -n, --network-off       Disable network completely (--network=none)
   -d, --dns <server>      DNS server (default: 1.1.1.1, env: AI_SANDBOX_DNS)
   -v, --verbose           Show the podman command being run
@@ -134,6 +145,24 @@ Built on **Fedora 43** and includes: Node.js, npm, Python 3.14 (default), Python
 - **Claude**: if `~/.claude` exists on the host, it is bind-mounted into the container for OAuth session persistence.
 - **Codex**: if `~/.codex` exists on the host, it is bind-mounted into the container for OAuth/cached login persistence.
 - **Cursor**: if `~/.cursor` exists on the host, it is bind-mounted into the container so `cursor-agent` has access to its project state and config.
+
+## Command Blocking (BPF LSM)
+
+You can optionally block specific commands inside the sandbox using a BPF LSM program that intercepts `execve` calls within the container's cgroup:
+
+```bash
+ai-sandbox claude ~/project --block-cmd "git:push"
+```
+
+This requires a kernel with `CONFIG_BPF_LSM=y` and `bpf` in the LSM list (`cat /sys/kernel/security/lsm`). Build the BPF loader first:
+
+```bash
+make -C bpf/
+```
+
+The BPF loader runs with `sudo` (required for loading BPF programs). The `ai-sandbox` wrapper handles this automatically when `--block-cmd` is passed. Blocking is scoped to the container's cgroup v2 — host processes are never affected.
+
+See [bpf/README.md](bpf/README.md) for full details on kernel requirements, build dependencies, and how it works.
 
 ## License
 

--- a/bpf/README.md
+++ b/bpf/README.md
@@ -2,24 +2,59 @@
 
 ## Overview
 
-TODO
+BPF LSM-based command blocker that hooks into `bprm_check_security` to prevent execution of specified commands inside containers. It uses cgroup v2 scoping so blocking only applies to the target container, not the host or other containers. Blocked commands are configured at runtime via the userspace loader — no recompilation needed to change the set of blocked commands.
 
 ## Kernel Requirements
 
-TODO
+The following kernel options must be enabled:
+
+```
+CONFIG_BPF=y
+CONFIG_BPF_SYSCALL=y
+CONFIG_BPF_LSM=y
+CONFIG_DEBUG_INFO_BTF=y
+```
+
+The kernel command line (or `CONFIG_LSM`) must include `bpf` in the LSM list. Verify with:
+
+```bash
+cat /sys/kernel/security/lsm
+# Should contain "bpf" in the comma-separated list
+```
+
+Fedora 43+ and recent Arch kernels have this enabled by default. On Gentoo, enable `CONFIG_BPF_LSM` and add `bpf` to `CONFIG_LSM` in your kernel config.
 
 ## Build Dependencies
 
-TODO
+```
+Fedora:  dnf install clang llvm libbpf-devel bpftool elfutils-libelf-devel zlib-devel
+Gentoo:  emerge -av sys-devel/clang sys-devel/llvm dev-libs/libbpf sys-apps/bpftool dev-libs/elfutils sys-libs/zlib
+```
 
 ## Build
 
-TODO
+```bash
+cd bpf/
+make
+```
 
 ## Usage
 
-TODO
+```bash
+# Standalone usage
+sudo ./loader --cgroup /sys/fs/cgroup/.../libpod-XXX.scope \
+              --block "git:push" \
+              --block "git:push --force" \
+              --verbose
+
+# Via ai-sandbox wrapper
+ai-sandbox claude ~/project --block-cmd "git:push"
+```
 
 ## How It Works
 
-TODO
+The userspace loader resolves the container's cgroup v2 path to a numeric cgroup ID using `name_to_handle_at`. It then opens and loads the compiled BPF object via the libbpf skeleton and populates two BPF maps: `target_cgroup`, which holds the single cgroup ID to scope enforcement to, and `blocked_cmds`, a hash map keyed by `(binary, arg1)` pairs representing the commands to block.
+
+Once the maps are populated, the loader attaches the BPF program to the LSM hook `bprm_check_security`, which the kernel invokes on every `execve` call. For each execution, the BPF program first checks whether the calling process belongs to the target cgroup. If it does, the program extracts the binary's basename from the full path and reads the first argument from userspace memory, then looks the pair up in the `blocked_cmds` map. If a match is found, it returns `-EPERM`, which causes the kernel to deny the execution. All other processes and non-matching commands are allowed through without interference.
+
+When the loader receives `SIGINT` or `SIGTERM`, it calls `block_commands_bpf__destroy()` to detach the BPF program, remove the maps, and release all resources. This ensures that blocking is cleanly removed when the loader exits.

--- a/test/test_bpf_blocker.sh
+++ b/test/test_bpf_blocker.sh
@@ -1,0 +1,334 @@
+#!/bin/bash
+# =============================================================================
+# End-to-end tests for the BPF LSM command blocker.
+# Requires root privileges and a built environment (loader + container images).
+#
+# Usage: sudo bash test/test_bpf_blocker.sh
+# =============================================================================
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+LOADER="${PROJECT_DIR}/bpf/loader"
+CONTAINER_NAME="test-bpf-$$"
+TEST_IMAGE="localhost/agent-claude:latest"
+
+# --- Prerequisites -----------------------------------------------------------
+
+check_prerequisites() {
+    echo "=== BPF Command Blocker — End-to-End Tests ==="
+    echo ""
+    echo "Checking prerequisites..."
+
+    local ok=true
+
+    if ! command -v podman &>/dev/null; then
+        echo -e "  ${RED}✗${NC} podman not found"
+        ok=false
+    else
+        echo -e "  ${GREEN}✓${NC} podman"
+    fi
+
+    if ! command -v bpftool &>/dev/null; then
+        echo -e "  ${RED}✗${NC} bpftool not found"
+        ok=false
+    else
+        echo -e "  ${GREEN}✓${NC} bpftool"
+    fi
+
+    if ! sudo -n true 2>/dev/null; then
+        echo -e "  ${RED}✗${NC} sudo access not available"
+        ok=false
+    else
+        echo -e "  ${GREEN}✓${NC} sudo"
+    fi
+
+    if [[ ! -x "$LOADER" ]]; then
+        echo -e "  ${YELLOW}!${NC} loader not found, attempting make -C bpf/"
+        if make -C "${PROJECT_DIR}/bpf/" &>/dev/null; then
+            echo -e "  ${GREEN}✓${NC} loader (built)"
+        else
+            echo -e "  ${RED}✗${NC} loader build failed"
+            ok=false
+        fi
+    else
+        echo -e "  ${GREEN}✓${NC} loader"
+    fi
+
+    if ! podman image exists "$TEST_IMAGE" 2>/dev/null; then
+        for img in localhost/agent-codex:latest localhost/agent-cursor:latest; do
+            if podman image exists "$img" 2>/dev/null; then
+                TEST_IMAGE="$img"
+                break
+            fi
+        done
+        if ! podman image exists "$TEST_IMAGE" 2>/dev/null; then
+            echo -e "  ${RED}✗${NC} no agent image found"
+            ok=false
+        else
+            echo -e "  ${GREEN}✓${NC} agent image ($TEST_IMAGE)"
+        fi
+    else
+        echo -e "  ${GREEN}✓${NC} agent image ($TEST_IMAGE)"
+    fi
+
+    if [[ ! -f /sys/kernel/btf/vmlinux ]]; then
+        echo -e "  ${RED}✗${NC} /sys/kernel/btf/vmlinux not found (no BTF support)"
+        ok=false
+    else
+        echo -e "  ${GREEN}✓${NC} BTF support"
+    fi
+
+    if ! cat /sys/kernel/security/lsm 2>/dev/null | grep -q bpf; then
+        echo -e "  ${RED}✗${NC} bpf not in LSM list (cat /sys/kernel/security/lsm)"
+        ok=false
+    else
+        echo -e "  ${GREEN}✓${NC} BPF LSM enabled"
+    fi
+
+    echo ""
+
+    if [[ "$ok" != true ]]; then
+        echo -e "${RED}Prerequisites not met. Aborting.${NC}"
+        exit 1
+    fi
+}
+
+# --- Test helpers ------------------------------------------------------------
+
+run_test() {
+    local name="$1"
+    echo -ne "  ${CYAN}TEST${NC}: ${name}... "
+}
+
+pass() {
+    echo -e "${GREEN}PASS${NC}"
+    ((PASS++))
+}
+
+fail() {
+    local reason="${1:-}"
+    echo -e "${RED}FAIL${NC}${reason:+ ($reason)}"
+    ((FAIL++))
+}
+
+resolve_cgroup() {
+    local container_id="$1"
+    local cg_path
+    cg_path=$(podman inspect --format '{{.CgroupPath}}' "$container_id" 2>/dev/null)
+
+    if [[ -z "$cg_path" ]]; then
+        echo ""
+        return
+    fi
+
+    local full_cg
+    if [[ "$cg_path" == /sys/fs/cgroup/* ]]; then
+        full_cg="$cg_path"
+    else
+        full_cg="/sys/fs/cgroup${cg_path}"
+    fi
+
+    if [[ ! -d "$full_cg" ]]; then
+        full_cg="/sys/fs/cgroup/user.slice/user-$(id -u).slice/user@$(id -u).service${cg_path}"
+    fi
+
+    if [[ ! -d "$full_cg" ]]; then
+        echo ""
+        return
+    fi
+
+    echo "$full_cg"
+}
+
+# Start a container + loader, sets CONTAINER_ID and LOADER_PID globals.
+# Usage: setup_blocked_container "git:push"
+setup_blocked_container() {
+    local block_rule="$1"
+    local tmpdir
+    tmpdir=$(mktemp -d)
+
+    git init "$tmpdir" &>/dev/null
+    git -C "$tmpdir" commit --allow-empty -m "init" &>/dev/null
+
+    CONTAINER_ID=$(podman run -d --rm \
+        --name "$CONTAINER_NAME" \
+        --userns=keep-id \
+        --cap-drop=ALL \
+        --read-only \
+        --tmpfs /tmp:rw \
+        --mount "type=tmpfs,destination=/home/agent,tmpfs-mode=0755,U=true" \
+        -v "${tmpdir}:/workspace:Z" \
+        -w /workspace \
+        "$TEST_IMAGE" sleep 300)
+
+    podman wait --condition=running "$CONTAINER_ID" >/dev/null 2>&1 || sleep 1
+
+    local full_cg
+    full_cg=$(resolve_cgroup "$CONTAINER_ID")
+
+    if [[ -z "$full_cg" ]]; then
+        echo -e "${RED}Could not resolve cgroup for container${NC}" >&2
+        teardown_container
+        return 1
+    fi
+
+    sudo "$LOADER" --cgroup "$full_cg" --block "$block_rule" &>/dev/null &
+    LOADER_PID=$!
+    sleep 1
+
+    TMPDIR_CLEANUP="$tmpdir"
+    return 0
+}
+
+teardown_container() {
+    if [[ -n "${LOADER_PID:-}" ]]; then
+        sudo kill "$LOADER_PID" 2>/dev/null || true
+        wait "$LOADER_PID" 2>/dev/null || true
+        unset LOADER_PID
+    fi
+    podman rm -f "$CONTAINER_NAME" 2>/dev/null || true
+    if [[ -n "${TMPDIR_CLEANUP:-}" ]]; then
+        rm -rf "$TMPDIR_CLEANUP"
+        unset TMPDIR_CLEANUP
+    fi
+}
+
+# --- Tests -------------------------------------------------------------------
+
+test_git_push_blocked() {
+    run_test "git push is blocked inside container"
+
+    if ! setup_blocked_container "git:push"; then
+        fail "setup failed"
+        return
+    fi
+
+    local output
+    local rc=0
+    output=$(podman exec "$CONTAINER_NAME" git push 2>&1) || rc=$?
+
+    if [[ $rc -ne 0 ]] && echo "$output" | grep -qi "operation not permitted\|permission denied\|EPERM"; then
+        pass
+    else
+        fail "exit=$rc, output: $output"
+    fi
+
+    teardown_container
+}
+
+test_git_commit_not_blocked() {
+    run_test "git commit is NOT blocked inside container"
+
+    if ! setup_blocked_container "git:push"; then
+        fail "setup failed"
+        return
+    fi
+
+    local rc=0
+    podman exec "$CONTAINER_NAME" git commit --allow-empty -m "test commit" &>/dev/null || rc=$?
+
+    if [[ $rc -eq 0 ]]; then
+        pass
+    else
+        fail "exit=$rc"
+    fi
+
+    teardown_container
+}
+
+test_git_pull_not_blocked() {
+    run_test "git pull is NOT blocked inside container"
+
+    if ! setup_blocked_container "git:push"; then
+        fail "setup failed"
+        return
+    fi
+
+    local output
+    local rc=0
+    output=$(podman exec "$CONTAINER_NAME" git pull 2>&1) || rc=$?
+
+    if echo "$output" | grep -qi "operation not permitted"; then
+        fail "got EPERM"
+    else
+        pass
+    fi
+
+    teardown_container
+}
+
+test_host_not_affected() {
+    run_test "git push works on the host (cgroup scoping)"
+
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    git init "$tmpdir" &>/dev/null
+    git -C "$tmpdir" commit --allow-empty -m "init" &>/dev/null
+
+    local output
+    local rc=0
+    output=$(git -C "$tmpdir" push 2>&1) || rc=$?
+
+    if echo "$output" | grep -qi "operation not permitted"; then
+        fail "host got EPERM"
+    else
+        pass
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+test_cleanup_after_loader_exit() {
+    run_test "BPF program is cleaned up after loader exit"
+
+    if ! setup_blocked_container "git:push"; then
+        fail "setup failed"
+        return
+    fi
+
+    sudo kill "$LOADER_PID" 2>/dev/null || true
+    wait "$LOADER_PID" 2>/dev/null || true
+    unset LOADER_PID
+
+    sleep 0.5
+
+    if sudo bpftool prog list 2>/dev/null | grep -q "block_cmd_check"; then
+        fail "BPF program still loaded"
+    else
+        pass
+    fi
+
+    teardown_container
+}
+
+# --- Main --------------------------------------------------------------------
+
+check_prerequisites
+
+echo "Running tests..."
+echo ""
+
+test_git_push_blocked
+test_git_commit_not_blocked
+test_git_pull_not_blocked
+test_host_not_affected
+test_cleanup_after_loader_exit
+
+echo ""
+echo "=============================="
+echo -e "  Results: ${GREEN}${PASS} passed${NC}, ${RED}${FAIL} failed${NC}"
+echo "=============================="
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
Create test/test_bpf_blocker.sh with five functional tests covering blocked command enforcement, non-blocked command passthrough, cgroup scoping to the container, and BPF cleanup on loader exit. Replace TODO placeholders in bpf/README.md with kernel requirements, build instructions, usage examples, and architecture explanation. Update the main README.md with the bpf/ and test/ directory structure, --block-cmd option, Security Model table entry, and a new Command Blocking section. Closes #14