### PR TITLE
Fix loader build: add _GNU_SOURCE and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# BPF build artifacts
+bpf/vmlinux.h
+bpf/block_commands.bpf.o
+bpf/block_commands.skel.h
+bpf/loader

--- a/bpf/block_commands.bpf.c
+++ b/bpf/block_commands.bpf.c
@@ -8,6 +8,7 @@
 #include "vmlinux.h"
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_core_read.h>
+#include <bpf/bpf_tracing.h>
 #include "config.h"
 
 struct blocked_cmd_key {

--- a/bpf/loader.c
+++ b/bpf/loader.c
@@ -4,6 +4,8 @@
 // Userspace loader (libbpf): loads the BPF program, populates blocked_cmds and
 // target_cgroup maps, attaches to LSM hook, handles cleanup on SIGINT/SIGTERM.
 
+#define _GNU_SOURCE
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Add _GNU_SOURCE define to loader.c to expose name_to_handle_at(), struct file_handle, and AT_EMPTY_PATH from glibc headers. Add .gitignore for BPF build artifacts (vmlinux.h, .bpf.o, .skel.h, loader).