### PR TITLE
Install BPF loader to ~/.local/bin instead of resolving relative to s…

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ This requires a kernel with `CONFIG_BPF_LSM=y` and `bpf` in the LSM list (`cat /
 make -C bpf/
 ```
 
+This compiles the loader and installs it to `~/.local/bin/ai-sandbox-loader`, where `ai-sandbox` expects to find it. You can override the install location with `make -C bpf/ LOADER_DIR=/other/path` and point the script to it via `AI_SANDBOX_BPF_LOADER=/other/path/ai-sandbox-loader`.
+
 The BPF loader runs with `sudo` (required for loading BPF programs). The `ai-sandbox` wrapper handles this automatically when `--block-cmd` is passed. Blocking is scoped to the container's cgroup v2 — host processes are never affected.
 
 See [bpf/README.md](bpf/README.md) for full details on kernel requirements, build dependencies, and how it works.

--- a/ai-sandbox
+++ b/ai-sandbox
@@ -172,12 +172,13 @@ if ! "${BUILDER}" image exists "${IMAGE}" 2>/dev/null; then
 fi
 
 # --- BPF loader path and validation -------------------------------------------
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-BPF_LOADER="${SCRIPT_DIR}/bpf/loader"
+BPF_LOADER="${AI_SANDBOX_BPF_LOADER:-${HOME}/.local/bin/ai-sandbox-loader}"
 
 if [[ ${#BLOCK_CMDS[@]} -gt 0 ]]; then
     if [[ ! -x "$BPF_LOADER" ]]; then
-        echo -e "${RED}Error: BPF loader not found. Run 'make -C bpf/' first.${NC}" >&2
+        echo -e "${RED}Error: BPF loader not found at ${BPF_LOADER}.${NC}" >&2
+        echo -e "${RED}Build it with 'make -C bpf/' (installs to ~/.local/bin/ai-sandbox-loader),${NC}" >&2
+        echo -e "${RED}or set AI_SANDBOX_BPF_LOADER=/path/to/loader.${NC}" >&2
         exit 1
     fi
     if ! sudo -n true 2>/dev/null && ! sudo -v; then

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -3,7 +3,7 @@
 #
 # Build system for BPF program and userspace loader.
 # Targets: vmlinux.h, block_commands.bpf.o, block_commands.skel.h, loader,
-#          clean, install.
+#          clean.
 #
 # Build dependencies:
 #   Fedora: dnf install clang llvm libbpf-devel bpftool elfutils-libelf-devel zlib-devel
@@ -15,10 +15,9 @@ BPFTOOL    ?= bpftool
 CC         ?= gcc
 ARCH       := $(shell uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/')
 VMLINUX    := /sys/kernel/btf/vmlinux
-PREFIX     ?= /usr/local
-DESTDIR    ?=
+LOADER_DIR ?= $(HOME)/.local/bin
 
-.PHONY: all clean install
+.PHONY: all clean
 
 all: loader
 
@@ -39,10 +38,9 @@ loader: loader.c block_commands.skel.h block_commands.h config.h
 		-I. \
 		-o loader loader.c \
 		-lbpf -lelf -lz
+	install -d $(LOADER_DIR)
+	install -m 755 loader $(LOADER_DIR)/ai-sandbox-loader
 
 clean:
 	rm -f vmlinux.h block_commands.bpf.o block_commands.skel.h loader
-
-install: loader
-	install -d $(DESTDIR)$(PREFIX)/bin
-	install -m 755 loader $(DESTDIR)$(PREFIX)/bin/bpf-sandbox-loader
+	rm -f $(LOADER_DIR)/ai-sandbox-loader

--- a/bpf/README.md
+++ b/bpf/README.md
@@ -38,6 +38,8 @@ cd bpf/
 make
 ```
 
+This compiles the BPF program and the userspace loader, then installs the loader to `~/.local/bin/ai-sandbox-loader`. Override with `make LOADER_DIR=/other/path`.
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
…cript location

The loader path was resolved via SCRIPT_DIR, which broke when ai-sandbox was invoked from outside the repo. The Makefile now auto-installs to ~/.local/bin/ai-sandbox-loader on build, and ai-sandbox looks for it there (overridable via AI_SANDBOX_BPF_LOADER).