### PR TITLE
Fix BPF command blocking: resolve leaf cgroup and split argv matching…

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,11 +148,34 @@ Built on **Fedora 43** and includes: Node.js, npm, Python 3.14 (default), Python
 
 ## Command Blocking (BPF LSM)
 
-You can optionally block specific commands inside the sandbox using a BPF LSM program that intercepts `execve` calls within the container's cgroup:
+You can optionally block specific commands inside the sandbox using eBPF programs that intercept `execve` calls within the container's cgroup. The `--block-cmd` (`-b`) flag is repeatable.
+
+The format is `binary:arg1` where `arg1` is optional:
 
 ```bash
+# Block git push (git with any other argument is allowed)
 ai-sandbox claude ~/project --block-cmd "git:push"
+
+# Block git entirely, regardless of arguments
+ai-sandbox claude ~/project --block-cmd "git:"
+
+# Block multiple commands
+ai-sandbox cursor ~/project \
+  --block-cmd "git:push" \
+  --block-cmd "git:push --force" \
+  --block-cmd "curl:" \
+  --block-cmd "wget:"
+
+# Combine with other options
+ai-sandbox codex ~/project --block-cmd "rm:" --network-off
 ```
+
+How blocking works depends on the rule type:
+
+- **Binary-only rules** (`git:`, `curl:`) — blocked via the LSM hook *before* exec completes. The command is never executed (`-EPERM`).
+- **Binary+arg rules** (`git:push`, `git:push --force`) — enforced via a tracepoint *after* exec, when argv is readable. The process is killed immediately (`SIGKILL`).
+
+### Setup
 
 This requires a kernel with `CONFIG_BPF_LSM=y` and `bpf` in the LSM list (`cat /sys/kernel/security/lsm`). Build the BPF loader first:
 

--- a/ai-sandbox
+++ b/ai-sandbox
@@ -356,6 +356,21 @@ if [[ ${#BLOCK_CMDS[@]} -gt 0 ]]; then
         exit 1
     fi
 
+    # Podman rootless creates a child cgroup (e.g. "container") under the
+    # scope where processes actually run.  Walk down to the leaf so the BPF
+    # cgroup ID matches what bpf_get_current_cgroup_id() returns.
+    while true; do
+        CHILDREN=()
+        for child in "$FULL_CGROUP"/*/; do
+            [[ -d "$child" ]] && CHILDREN+=("${child%/}")
+        done
+        if [[ ${#CHILDREN[@]} -eq 1 ]]; then
+            FULL_CGROUP="${CHILDREN[0]}"
+        else
+            break
+        fi
+    done
+
     # Build loader arguments
     LOADER_ARGS=(--cgroup "$FULL_CGROUP")
     for bc in "${BLOCK_CMDS[@]}"; do
@@ -366,6 +381,7 @@ if [[ ${#BLOCK_CMDS[@]} -gt 0 ]]; then
     fi
 
     if [[ "$VERBOSE" == true ]]; then
+        echo -e "${CYAN}Cgroup path: ${FULL_CGROUP}${NC}"
         echo -e "${CYAN}BPF loader command:${NC}"
         echo "  sudo ${BPF_LOADER} ${LOADER_ARGS[*]}"
         echo ""

--- a/bpf/block_commands.bpf.c
+++ b/bpf/block_commands.bpf.c
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // another-ai-sandbox
 //
-// BPF LSM program that hooks into bprm_check_security to block execution of
-// configured commands, scoped to a specific cgroup v2. Populated via userspace
-// loader.
+// BPF programs for command blocking, scoped to a specific cgroup v2.
+//
+// Two hooks work together:
+//   1. LSM bprm_check_security — blocks binary-only rules (arg1 == "")
+//      by returning -EPERM before exec completes.
+//   2. tp_btf/sched_process_exec — enforces binary+arg1 rules after exec,
+//      when argv is readable from user memory.  Sends SIGKILL on match.
 
 #include "vmlinux.h"
 #include <bpf/bpf_helpers.h>
@@ -16,12 +20,21 @@ struct blocked_cmd_key {
     char arg1[MAX_ARG_LEN];
 };
 
+/* Rules with arg1 == "" — checked in LSM hook (prevents exec) */
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
     __type(key, struct blocked_cmd_key);
     __type(value, __u8);
     __uint(max_entries, MAX_BLOCKED_CMDS);
 } blocked_cmds SEC(".maps");
+
+/* Rules with arg1 != "" — checked in tracepoint after exec (SIGKILL) */
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, struct blocked_cmd_key);
+    __type(value, __u8);
+    __uint(max_entries, MAX_BLOCKED_CMDS);
+} blocked_cmds_arg SEC(".maps");
 
 struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);
@@ -30,30 +43,21 @@ struct {
     __uint(max_entries, 1);
 } target_cgroup SEC(".maps");
 
-SEC("lsm/bprm_check_security")
-int BPF_PROG(block_cmd_check, struct linux_binprm *bprm, int ret)
+/*
+ * Extract basename from a kernel filename pointer into dst.
+ * Returns the length from bpf_probe_read_kernel_str, or <= 0 on error.
+ */
+static __always_inline int read_basename(char *dst, int dst_len,
+                                         const char *fname_ptr)
 {
-    if (ret != 0)
-        return ret;
-
-    __u32 zero = 0;
-    __u64 *target_cg = bpf_map_lookup_elem(&target_cgroup, &zero);
-    if (!target_cg)
-        return 0;
-
-    __u64 current_cg = bpf_get_current_cgroup_id();
-    if (current_cg != *target_cg)
-        return 0;
-
     char filename[MAX_BIN_LEN];
     int fname_len;
-    const char *fname_ptr = BPF_CORE_READ(bprm, filename);
 
-    fname_len = bpf_probe_read_kernel_str(filename, sizeof(filename), fname_ptr);
+    fname_len = bpf_probe_read_kernel_str(filename, sizeof(filename),
+                                          fname_ptr);
     if (fname_len <= 0)
-        return 0;
+        return fname_len;
 
-    /* Extract basename: scan backwards for '/' */
     int basename_off = 0;
     for (int i = fname_len - 1; i >= 0; i--) {
         if (i >= MAX_BIN_LEN)
@@ -64,28 +68,70 @@ int BPF_PROG(block_cmd_check, struct linux_binprm *bprm, int ret)
         }
     }
 
+    basename_off &= (MAX_BIN_LEN - 1);
+    return bpf_probe_read_kernel_str(dst, dst_len,
+                                     fname_ptr + basename_off);
+}
+
+static __always_inline int check_target_cgroup(void)
+{
+    __u32 zero = 0;
+    __u64 *target_cg = bpf_map_lookup_elem(&target_cgroup, &zero);
+    if (!target_cg)
+        return 0;
+    return bpf_get_current_cgroup_id() == *target_cg;
+}
+
+/* --- Hook 1: LSM — block binary-only rules before exec completes --- */
+
+SEC("lsm/bprm_check_security")
+int BPF_PROG(block_cmd_check, struct linux_binprm *bprm, int ret)
+{
+    if (ret != 0)
+        return ret;
+
+    if (!check_target_cgroup())
+        return 0;
+
+    const char *fname_ptr = BPF_CORE_READ(bprm, filename);
     struct blocked_cmd_key key = {};
 
-    /*
-     * Re-read just the basename directly from kernel memory.
-     * This avoids variable-offset stack access (filename[basename_off + i])
-     * which the BPF verifier rejects. The mask ensures the verifier can
-     * prove basename_off is within [0, MAX_BIN_LEN).
-     */
-    basename_off &= (MAX_BIN_LEN - 1);
-    bpf_probe_read_kernel_str(key.binary, MAX_BIN_LEN,
-                              fname_ptr + basename_off);
+    if (read_basename(key.binary, MAX_BIN_LEN, fname_ptr) <= 0)
+        return 0;
 
-    /* Read argv[1] from bprm->mm->arg_start */
-    unsigned long arg_start = BPF_CORE_READ(bprm, mm, arg_start);
-    unsigned long arg_end = BPF_CORE_READ(bprm, mm, arg_end);
+    __u8 *blocked = bpf_map_lookup_elem(&blocked_cmds, &key);
+    if (blocked) {
+        __u32 pid = bpf_get_current_pid_tgid() >> 32;
+        bpf_printk("BLOCKED: %s (pid %d)", key.binary, pid);
+        return -1;
+    }
+
+    return 0;
+}
+
+/* --- Hook 2: tracepoint — enforce binary+arg rules post-exec --- */
+
+SEC("tp_btf/sched_process_exec")
+int BPF_PROG(block_cmd_arg_check, struct task_struct *p, pid_t old_pid,
+             struct linux_binprm *bprm)
+{
+    if (!check_target_cgroup())
+        return 0;
+
+    const char *fname_ptr = BPF_CORE_READ(bprm, filename);
+    struct blocked_cmd_key key = {};
+
+    if (read_basename(key.binary, MAX_BIN_LEN, fname_ptr) <= 0)
+        return 0;
+
+    /* After exec, argv is in user memory at mm->arg_start */
+    unsigned long arg_start = BPF_CORE_READ(p, mm, arg_start);
+    unsigned long arg_end = BPF_CORE_READ(p, mm, arg_end);
 
     if (arg_start != 0 && arg_end > arg_start) {
-        /* Read argv[0] to determine its length */
         char argv0[MAX_ARG_LEN];
         int len0 = bpf_probe_read_user_str(argv0, sizeof(argv0),
                                            (void *)arg_start);
-
         if (len0 > 0) {
             unsigned long arg1_addr = arg_start + (__u64)len0;
             if (arg1_addr < arg_end)
@@ -94,11 +140,11 @@ int BPF_PROG(block_cmd_check, struct linux_binprm *bprm, int ret)
         }
     }
 
-    __u8 *blocked = bpf_map_lookup_elem(&blocked_cmds, &key);
+    __u8 *blocked = bpf_map_lookup_elem(&blocked_cmds_arg, &key);
     if (blocked) {
         __u32 pid = bpf_get_current_pid_tgid() >> 32;
-        bpf_printk("BLOCKED: %s %s (pid %d)", key.binary, key.arg1, pid);
-        return -1;
+        bpf_printk("BLOCKED+KILL: %s %s (pid %d)", key.binary, key.arg1, pid);
+        bpf_send_signal(SIGKILL);
     }
 
     return 0;

--- a/bpf/config.h
+++ b/bpf/config.h
@@ -10,4 +10,8 @@
 #define MAX_ARG_LEN 64
 #define MAX_BLOCKED_CMDS 64
 
+#ifndef SIGKILL
+#define SIGKILL 9
+#endif
+
 #endif

--- a/bpf/loader.c
+++ b/bpf/loader.c
@@ -208,6 +208,7 @@ int main(int argc, char **argv)
     }
 
     int cmds_map_fd = bpf_map__fd(skel->maps.blocked_cmds);
+    int cmds_arg_map_fd = bpf_map__fd(skel->maps.blocked_cmds_arg);
     __u8 val = 1;
 
     for (int i = 0; i < num_entries; i++) {
@@ -215,7 +216,9 @@ int main(int argc, char **argv)
         memcpy(key.binary, entries[i].binary, MAX_BIN_LEN);
         memcpy(key.arg1, entries[i].arg1, MAX_ARG_LEN);
 
-        err = bpf_map_update_elem(cmds_map_fd, &key, &val, BPF_ANY);
+        int fd = (entries[i].arg1[0] == '\0') ? cmds_map_fd
+                                              : cmds_arg_map_fd;
+        err = bpf_map_update_elem(fd, &key, &val, BPF_ANY);
         if (err) {
             fprintf(stderr, "Error: failed to add blocked command '%s:%s': %s\n",
                     entries[i].binary, entries[i].arg1, strerror(errno));


### PR DESCRIPTION
… into post-exec hook

During bprm_check_security the new mm is not yet active, so argv is unreadable from BPF.  Split blocking into two hooks: the LSM hook handles binary-only rules (arg1=="") by returning -EPERM, while a new tp_btf/sched_process_exec hook enforces binary+arg1 rules post-exec via SIGKILL when argv is available in user memory. Also walk the cgroup hierarchy to the leaf child so the cgroup ID matches what bpf_get_current_cgroup_id() returns inside rootless podman containers.