### PR TITLE
Disable --cpus flag to fix crun failure on kernels without CONFIG_CFS…

### DIFF
--- a/ai-sandbox
+++ b/ai-sandbox
@@ -201,7 +201,10 @@ CMD=(
     --pids-limit="${MAX_PIDS}"              # Prevent fork bombs
 
     # === RESOURCES ===
-    --cpus="${MAX_CPUS}"
+    # NOTE: --cpus requires CONFIG_CFS_BANDWIDTH=y in the kernel.
+    # If your kernel lacks it, cpu.max won't exist and crun will fail.
+    # Uncomment the next line if your kernel supports CFS bandwidth:
+    # --cpus="${MAX_CPUS}"
     --memory="${MAX_MEM}"
 
     # === FILESYSTEM ===


### PR DESCRIPTION
…_BANDWIDTH

The cpu.max cgroup v2 file doesn't exist when the kernel is built without CONFIG_CFS_BANDWIDTH, causing crun to fail with "open cpu.max for writing: No such file or directory".