### PR TITLE
Add binutils to base image (remove as/ld for hardening)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Installed via the official `cursor.com/install` script. The installation is copi
 
 ## Base Image
 
-Built on **Fedora 43** and includes: Node.js, npm, Python 3.14 (default), Python 3.13, Python 3.12 (each with devel and libs — ready for `python3.XX -m venv`), pytest, ruff, Git, curl, wget, ripgrep, fd-find, jq, yq, tree, Ansible, ansible-lint, ShellCheck, OpenShift client (`oc`), strace, and standard GNU utilities (sed, gawk, grep, findutils, diffutils, patch, tar, gzip, unzip).
+Built on **Fedora 43** and includes: Node.js, npm, Python 3.14 (default), Python 3.13, Python 3.12 (each with devel and libs — ready for `python3.XX -m venv`), pytest, ruff, Git, curl, wget, ripgrep, fd-find, jq, yq, tree, Ansible, ansible-lint, ShellCheck, OpenShift client (`oc`), strace, binutils (strings, objdump, nm, readelf, etc. — `as` and `ld` are removed for hardening), and standard GNU utilities (sed, gawk, grep, findutils, diffutils, patch, tar, gzip, unzip).
 
 ## Notes
 

--- a/base/Containerfile
+++ b/base/Containerfile
@@ -35,6 +35,7 @@ RUN dnf install -y \
         tree \
         ansible \
         ansible-lint \
+        binutils \
         file \
         less \
         which \
@@ -48,6 +49,7 @@ RUN dnf install -y \
         ShellCheck \
         ruff \
         python3-pytest \
+    && rm -f /usr/bin/as /usr/bin/ld /usr/bin/ld.bfd \
     && dnf clean all \
     && rm -rf /var/cache/dnf
 


### PR DESCRIPTION
Install binutils for binary analysis tools (strings, objdump, nm, readelf, etc.). Assembler (as) and linker (ld, ld.bfd) are removed from the image to avoid exposing unnecessary build capabilities inside the sandbox.