### PR TITLE
feat: configurable /home/agent tmpfs size with project space check

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ Options:
   -n, --network-off       Disable network completely (--network=none)
   -d, --dns <server>      DNS server (default: 1.1.1.1, env: AI_SANDBOX_DNS)
       --home-size <size>   Size of /home/agent tmpfs (default: 1g, units: b, k, m, g)
-      --skip-space-check   Skip project dir vs home size check (warn instead of error)
   -v, --verbose           Show the podman command being run
   -h, --help              Show help
 ```

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Options:
   -b, --block-cmd <b:a>   Block command inside container (repeatable, e.g. "git:push")
   -n, --network-off       Disable network completely (--network=none)
   -d, --dns <server>      DNS server (default: 1.1.1.1, env: AI_SANDBOX_DNS)
+      --home-size <size>   Size of /home/agent tmpfs (default: 1g, units: b, k, m, g)
+      --skip-space-check   Skip project dir vs home size check (warn instead of error)
   -v, --verbose           Show the podman command being run
   -h, --help              Show help
 ```
@@ -123,7 +125,7 @@ MAX_CPUS="2"           # Number of CPUs
 MAX_MEM="4g"           # RAM limit
 MAX_PIDS="512"         # Process limit
 TMPFS_TMP_SIZE="1g"    # /tmp size
-TMPFS_HOME_SIZE="512m" # /home/agent size
+TMPFS_HOME_SIZE="1g"   # /home/agent size (units: b, k, m, g)
 NETWORK_MODE="pasta"   # "pasta" (fast) or "slirp4netns" (compatible)
 DNS="1.1.1.1"          # Default DNS (override with --dns or AI_SANDBOX_DNS)
 ```

--- a/ai-sandbox
+++ b/ai-sandbox
@@ -54,18 +54,6 @@ validate_size() {
     fi
 }
 
-size_to_bytes() {
-    local value="$1"
-    local num="${value%%[a-z]*}"
-    local suffix="${value##*[0-9]}"
-    case "$suffix" in
-        b) echo $(( num )) ;;
-        k) echo $(( num * 1024 )) ;;
-        m) echo $(( num * 1024 * 1024 )) ;;
-        g) echo $(( num * 1024 * 1024 * 1024 )) ;;
-    esac
-}
-
 usage() {
     echo -e "${CYAN}ai-sandbox${NC} - Starts an AI agent in a sandboxed container"
     echo ""
@@ -82,7 +70,6 @@ usage() {
     echo "  -d, --dns <server>      DNS server (default: 1.1.1.1, env: AI_SANDBOX_DNS)"
     echo "      --home-size <size>  Size of /home/agent tmpfs (default: ${TMPFS_HOME_SIZE})"
     echo "                          Units: b (bytes), k (kilobytes), m (megabytes), g (gigabytes)"
-    echo "      --skip-space-check  Skip project directory vs home size check (warn only)"
     echo "  -v, --verbose           Show the podman command being run"
     echo "  -h, --help              Show this help"
     exit 0
@@ -93,7 +80,6 @@ AGENT=""
 PROJECT_DIR=""
 NETWORK_OFF=false
 VERBOSE=false
-SKIP_SPACE_CHECK=false
 EXTRA_ARGS=()
 BLOCK_CMDS=()
 
@@ -104,7 +90,6 @@ while [[ $# -gt 0 ]]; do
         -n|--network-off) NETWORK_OFF=true; shift ;;
         -d|--dns)     DNS="$2"; shift 2 ;;
         --home-size)  TMPFS_HOME_SIZE="$2"; shift 2 ;;
-        --skip-space-check) SKIP_SPACE_CHECK=true; shift ;;
         -v|--verbose) VERBOSE=true; shift ;;
         --)           shift; EXTRA_ARGS=("$@"); break ;;
         -*)           echo -e "${RED}Unknown option: $1${NC}" >&2; exit 1 ;;
@@ -142,27 +127,6 @@ fi
 
 # --- Validate home size -------------------------------------------------------
 validate_size "$TMPFS_HOME_SIZE"
-
-# --- Check project directory size vs home tmpfs size --------------------------
-PROJECT_SIZE_BYTES=$(du -sb "$PROJECT_DIR" 2>/dev/null | awk '{print $1}')
-HOME_SIZE_BYTES=$(size_to_bytes "$TMPFS_HOME_SIZE")
-
-if [[ -n "$PROJECT_SIZE_BYTES" && -n "$HOME_SIZE_BYTES" ]] && (( PROJECT_SIZE_BYTES > HOME_SIZE_BYTES )); then
-    PROJECT_SIZE_HUMAN=$(du -sh "$PROJECT_DIR" 2>/dev/null | awk '{print $1}')
-    if [[ "$SKIP_SPACE_CHECK" == true ]]; then
-        echo -e "${YELLOW}Warning: project directory (${PROJECT_SIZE_HUMAN}) exceeds home tmpfs size (${TMPFS_HOME_SIZE}).${NC}" >&2
-        echo -e "${YELLOW}The agent home may run out of space. Continuing due to --skip-space-check.${NC}" >&2
-        echo ""
-    else
-        echo -e "${RED}Error: project directory (${PROJECT_SIZE_HUMAN}) exceeds home tmpfs size (${TMPFS_HOME_SIZE}).${NC}" >&2
-        echo -e "${RED}The agent may not have enough space in /home/agent.${NC}" >&2
-        echo ""
-        echo "Options:" >&2
-        echo "  --home-size <size>     Increase home tmpfs (e.g. --home-size 4g)" >&2
-        echo "  --skip-space-check     Skip this check and start anyway" >&2
-        exit 1
-    fi
-fi
 
 # --- Select image and API key -------------------------------------------------
 case "$AGENT" in

--- a/ai-sandbox
+++ b/ai-sandbox
@@ -31,7 +31,7 @@ MAX_CPUS="2"
 MAX_MEM="4g"
 MAX_PIDS="512"
 TMPFS_TMP_SIZE="1g"
-TMPFS_HOME_SIZE="512m"
+TMPFS_HOME_SIZE="1g"
 NETWORK_MODE="pasta"           # "pasta" (fast, recommended) or "slirp4netns"
 DNS="${AI_SANDBOX_DNS:-1.1.1.1}"  # override with AI_SANDBOX_DNS env var or --dns flag
 ENV_FILE="${HOME}/.config/ai-sandbox/env"
@@ -43,6 +43,28 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 CYAN='\033[0;36m'
 NC='\033[0m'
+
+validate_size() {
+    local value="$1"
+    if [[ ! "$value" =~ ^[0-9]+[bkmg]$ ]]; then
+        echo -e "${RED}Error: invalid size '${value}'.${NC}" >&2
+        echo "Use a number followed by a unit: b (bytes), k (kilobytes), m (megabytes), g (gigabytes)" >&2
+        echo "Examples: 512m, 1g, 2g, 4096m" >&2
+        exit 1
+    fi
+}
+
+size_to_bytes() {
+    local value="$1"
+    local num="${value%%[a-z]*}"
+    local suffix="${value##*[0-9]}"
+    case "$suffix" in
+        b) echo $(( num )) ;;
+        k) echo $(( num * 1024 )) ;;
+        m) echo $(( num * 1024 * 1024 )) ;;
+        g) echo $(( num * 1024 * 1024 * 1024 )) ;;
+    esac
+}
 
 usage() {
     echo -e "${CYAN}ai-sandbox${NC} - Starts an AI agent in a sandboxed container"
@@ -58,6 +80,9 @@ usage() {
     echo "  -b, --block-cmd <b:a>   Block command inside container (repeatable, e.g. \"git:push\")"
     echo "  -n, --network-off       Disable network (no API, local only)"
     echo "  -d, --dns <server>      DNS server (default: 1.1.1.1, env: AI_SANDBOX_DNS)"
+    echo "      --home-size <size>  Size of /home/agent tmpfs (default: ${TMPFS_HOME_SIZE})"
+    echo "                          Units: b (bytes), k (kilobytes), m (megabytes), g (gigabytes)"
+    echo "      --skip-space-check  Skip project directory vs home size check (warn only)"
     echo "  -v, --verbose           Show the podman command being run"
     echo "  -h, --help              Show this help"
     exit 0
@@ -68,6 +93,7 @@ AGENT=""
 PROJECT_DIR=""
 NETWORK_OFF=false
 VERBOSE=false
+SKIP_SPACE_CHECK=false
 EXTRA_ARGS=()
 BLOCK_CMDS=()
 
@@ -77,6 +103,8 @@ while [[ $# -gt 0 ]]; do
         -b|--block-cmd) BLOCK_CMDS+=("$2"); shift 2 ;;
         -n|--network-off) NETWORK_OFF=true; shift ;;
         -d|--dns)     DNS="$2"; shift 2 ;;
+        --home-size)  TMPFS_HOME_SIZE="$2"; shift 2 ;;
+        --skip-space-check) SKIP_SPACE_CHECK=true; shift ;;
         -v|--verbose) VERBOSE=true; shift ;;
         --)           shift; EXTRA_ARGS=("$@"); break ;;
         -*)           echo -e "${RED}Unknown option: $1${NC}" >&2; exit 1 ;;
@@ -110,6 +138,30 @@ PROJECT_DIR="$(realpath "$PROJECT_DIR")"
 if [[ ! -d "$PROJECT_DIR" ]]; then
     echo -e "${RED}Error: directory not found: ${PROJECT_DIR}${NC}" >&2
     exit 1
+fi
+
+# --- Validate home size -------------------------------------------------------
+validate_size "$TMPFS_HOME_SIZE"
+
+# --- Check project directory size vs home tmpfs size --------------------------
+PROJECT_SIZE_BYTES=$(du -sb "$PROJECT_DIR" 2>/dev/null | awk '{print $1}')
+HOME_SIZE_BYTES=$(size_to_bytes "$TMPFS_HOME_SIZE")
+
+if [[ -n "$PROJECT_SIZE_BYTES" && -n "$HOME_SIZE_BYTES" ]] && (( PROJECT_SIZE_BYTES > HOME_SIZE_BYTES )); then
+    PROJECT_SIZE_HUMAN=$(du -sh "$PROJECT_DIR" 2>/dev/null | awk '{print $1}')
+    if [[ "$SKIP_SPACE_CHECK" == true ]]; then
+        echo -e "${YELLOW}Warning: project directory (${PROJECT_SIZE_HUMAN}) exceeds home tmpfs size (${TMPFS_HOME_SIZE}).${NC}" >&2
+        echo -e "${YELLOW}The agent home may run out of space. Continuing due to --skip-space-check.${NC}" >&2
+        echo ""
+    else
+        echo -e "${RED}Error: project directory (${PROJECT_SIZE_HUMAN}) exceeds home tmpfs size (${TMPFS_HOME_SIZE}).${NC}" >&2
+        echo -e "${RED}The agent may not have enough space in /home/agent.${NC}" >&2
+        echo ""
+        echo "Options:" >&2
+        echo "  --home-size <size>     Increase home tmpfs (e.g. --home-size 4g)" >&2
+        echo "  --skip-space-check     Skip this check and start anyway" >&2
+        exit 1
+    fi
 fi
 
 # --- Select image and API key -------------------------------------------------
@@ -286,6 +338,7 @@ fi
 echo -e "${GREEN}Starting ${AGENT} in sandbox${NC} (${PROJECT_DIR})"
 echo -e "  Container: ${CONTAINER_NAME}"
 echo -e "  Resources: ${MAX_CPUS} CPU, ${MAX_MEM} RAM, ${MAX_PIDS} PIDs max"
+echo -e "  Home size: ${TMPFS_HOME_SIZE}"
 echo -e "  Network:   $("${NETWORK_OFF}" && echo 'DISABLED' || echo "${NETWORK_MODE} (dns: ${DNS})")"
 if [[ ${#BLOCK_CMDS[@]} -gt 0 ]]; then
     echo -e "  Blocked:  ${BLOCK_CMDS[*]}"


### PR DESCRIPTION
Raise TMPFS_HOME_SIZE default from 512m to 1g and add --home-size flag so users can override it at runtime. Validate the value against podman's standard size suffixes (b/k/m/g). Before launching the container, compare the project directory size (du -sb) against the home tmpfs size and abort if it exceeds it, unless --skip-space-check is passed (prints a warning instead).