### PR TITLE
Mount project at /workspace/<project-name> instead of /workspace

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,10 +14,18 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@2.0.0
-        with:
-          scandir: .
-          additional_files: ai-sandbox
+        run: |
+          shopt -s globstar nullglob
+          files=()
+          for f in **/*.sh **/*.bash; do
+            files+=("$f")
+          done
+          for f in ai-sandbox; do
+            [[ -f "$f" ]] && files+=("$f")
+          done
+          if [[ ${#files[@]} -gt 0 ]]; then
+            shellcheck --format=gcc "${files[@]}"
+          fi
 
   hadolint:
     name: Hadolint

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Every container is launched with the following hardening measures:
 | `--network=pasta`             | Kernel-backed isolated network (fast, uses user namespaces)|
 | `--tmpfs /tmp`                | Temporary writable area, destroyed at session end          |
 | `--mount type=tmpfs,dst=/home/agent` | Agent home on tmpfs (mode 0755), destroyed at session end |
-| Bind mount only `/workspace`  | Agent sees ONLY the project directory                      |
+| Bind mount only `/workspace/<project-name>` | Agent sees ONLY the project directory                      |
 | BPF LSM command blocker       | Blocks specific commands (e.g. git push) inside the container via eBPF |
 
 ## Usage

--- a/ai-sandbox
+++ b/ai-sandbox
@@ -140,6 +140,14 @@ if [[ ! -d "$PROJECT_DIR" ]]; then
     exit 1
 fi
 
+# Mount under /workspace/<name> so each project gets a distinct path for agent state
+PROJECT_NAME="$(basename "$PROJECT_DIR")"
+if [[ -z "$PROJECT_NAME" || "$PROJECT_NAME" == "." || "$PROJECT_NAME" == ".." || "$PROJECT_NAME" == */* || "$PROJECT_NAME" == *$'\0'* ]]; then
+    echo -e "${RED}Error: invalid project directory name: '${PROJECT_NAME}'${NC}" >&2
+    exit 1
+fi
+CONTAINER_WORKDIR="/workspace/${PROJECT_NAME}"
+
 # --- Validate home size -------------------------------------------------------
 validate_size "$TMPFS_HOME_SIZE"
 
@@ -240,14 +248,14 @@ CMD=(
 
     # === FILESYSTEM ===
     # Container is read-only, except:
-    #   - /workspace: project directory (bind mount rw)
+    #   - /workspace/<project-name>: project directory (bind mount rw)
     #   - /tmp: tmpfs for temporary files
     #   - /home/agent: tmpfs for agent config/cache (mode=0755 for bind mounts)
     --read-only
-    -v "${PROJECT_DIR}:/workspace:Z"
+    -v "${PROJECT_DIR}:${CONTAINER_WORKDIR}:Z"
     --tmpfs "/tmp:rw,size=${TMPFS_TMP_SIZE}"
     --mount "type=tmpfs,destination=/home/agent,tmpfs-size=${TMPFS_HOME_SIZE},tmpfs-mode=0755,U=true"
-    -w /workspace
+    -w "${CONTAINER_WORKDIR}"
 
     # === NETWORK ===
     # slirp4netns: userspace network stack, isolated from host

--- a/ai-sandbox
+++ b/ai-sandbox
@@ -142,7 +142,7 @@ fi
 
 # Mount under /workspace/<name> so each project gets a distinct path for agent state
 PROJECT_NAME="$(basename "$PROJECT_DIR")"
-if [[ -z "$PROJECT_NAME" || "$PROJECT_NAME" == "." || "$PROJECT_NAME" == ".." || "$PROJECT_NAME" == */* || "$PROJECT_NAME" == *$'\0'* ]]; then
+if [[ -z "$PROJECT_NAME" || "$PROJECT_NAME" == "." || "$PROJECT_NAME" == ".." || "$PROJECT_NAME" == */* ]]; then
     echo -e "${RED}Error: invalid project directory name: '${PROJECT_NAME}'${NC}" >&2
     exit 1
 fi

--- a/test/test_bpf_blocker.sh
+++ b/test/test_bpf_blocker.sh
@@ -88,7 +88,7 @@ check_prerequisites() {
         echo -e "  ${GREEN}✓${NC} BTF support"
     fi
 
-    if ! cat /sys/kernel/security/lsm 2>/dev/null | grep -q bpf; then
+    if ! grep -q bpf /sys/kernel/security/lsm 2>/dev/null; then
         echo -e "  ${RED}✗${NC} bpf not in LSM list (cat /sys/kernel/security/lsm)"
         ok=false
     else

--- a/test/test_bpf_blocker.sh
+++ b/test/test_bpf_blocker.sh
@@ -160,6 +160,9 @@ setup_blocked_container() {
     git init "$tmpdir" &>/dev/null
     git -C "$tmpdir" commit --allow-empty -m "init" &>/dev/null
 
+    local workdir
+    workdir="/workspace/$(basename "$tmpdir")"
+
     CONTAINER_ID=$(podman run -d --rm \
         --name "$CONTAINER_NAME" \
         --userns=keep-id \
@@ -167,8 +170,8 @@ setup_blocked_container() {
         --read-only \
         --tmpfs /tmp:rw \
         --mount "type=tmpfs,destination=/home/agent,tmpfs-mode=0755,U=true" \
-        -v "${tmpdir}:/workspace:Z" \
-        -w /workspace \
+        -v "${tmpdir}:${workdir}:Z" \
+        -w "${workdir}" \
         "$TEST_IMAGE" sleep 300)
 
     podman wait --condition=running "$CONTAINER_ID" >/dev/null 2>&1 || sleep 1


### PR DESCRIPTION
Give each project a distinct in-container path so agents that key state by working directory (e.g. Claude Code persistent memory) no longer collide across projects.