### PR TITLE
fix: build agent user with host UID/GID to prevent permission errors

### DIFF
--- a/ai-sandbox-build
+++ b/ai-sandbox-build
@@ -56,6 +56,8 @@ build_image() {
     local name="$1"
     local dir="$2"
     local tag="$3"
+    shift 3
+    local extra_args=("$@")
 
     if [[ ! -f "${dir}/Containerfile" ]]; then
         err "Containerfile not found: ${dir}/Containerfile"
@@ -66,6 +68,7 @@ build_image() {
     "${BUILDER}" build \
         --format docker \
         --tag "${tag}" \
+        ${extra_args[@]+"${extra_args[@]}"} \
         --file "${dir}/Containerfile" \
         "${dir}"
     log "${name} built successfully"
@@ -78,7 +81,9 @@ pull_base_image() {
 
 build_base() {
     pull_base_image
-    build_image "base" "${DATA_DIR}/base" "localhost/agent-base:latest"
+    build_image "base" "${DATA_DIR}/base" "localhost/agent-base:latest" \
+        --build-arg "AGENT_UID=$(id -u)" \
+        --build-arg "AGENT_GID=$(id -g)"
 }
 
 build_claude() {

--- a/base/Containerfile
+++ b/base/Containerfile
@@ -59,7 +59,12 @@ RUN curl -fsSL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/
     && chmod 755 /usr/local/bin/oc /usr/local/bin/kubectl
 
 # Non-root user for agent execution
-RUN useradd -m -s /bin/bash agent
+# UID/GID default to 1000; override at build time with:
+#   --build-arg AGENT_UID=$(id -u) --build-arg AGENT_GID=$(id -g)
+ARG AGENT_UID=1000
+ARG AGENT_GID=1000
+RUN groupadd -g "${AGENT_GID}" agent \
+    && useradd -m -s /bin/bash -u "${AGENT_UID}" -g "${AGENT_GID}" agent
 
 # Standard working directory
 WORKDIR /workspace

--- a/base/Containerfile
+++ b/base/Containerfile
@@ -64,7 +64,7 @@ RUN curl -fsSL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/
 ARG AGENT_UID=1000
 ARG AGENT_GID=1000
 RUN groupadd -g "${AGENT_GID}" agent \
-    && useradd -m -s /bin/bash -u "${AGENT_UID}" -g "${AGENT_GID}" agent
+    && useradd -l -m -s /bin/bash -u "${AGENT_UID}" -g "${AGENT_GID}" agent
 
 # Standard working directory
 WORKDIR /workspace


### PR DESCRIPTION
Users with UID/GID != 1000 experienced write failures inside the container (e.g. /home/agent/.cursor) because the image-baked "agent" user was hardcoded to 1000:1000.
Add AGENT_UID/AGENT_GID build-args (default 1000) to the base Containerfile and pass the caller's id -u / id -g at build time from ai-sandbox-build, so the in-container user always matches the host.