### PR TITLE
Mount ~/.config/cursor as rw directory instead of auth.json ro

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Installed via `npm install -g @openai/codex`. Two authentication methods are sup
 
 ### Cursor Agent
 
-Installed via the official `cursor.com/install` script. The installation is copied to `/opt/cursor-agent` at build time so that it survives the tmpfs mount on `/home/agent` at runtime. Authenticates through `CURSOR_API_KEY` or via `~/.config/cursor/auth.json` (mounted read-only into the container).
+Installed via the official `cursor.com/install` script. The installation is copied to `/opt/cursor-agent` at build time so that it survives the tmpfs mount on `/home/agent` at runtime. Authenticates through `CURSOR_API_KEY` or via `~/.config/cursor/` (bind-mounted read-write into the container). The `~/.config/cursor/` directory is created automatically by `install.sh` if it doesn't exist.
 
 ## Base Image
 
@@ -168,7 +168,7 @@ Built on **Fedora 43** and includes: Node.js, npm, Python 3.14 (default), Python
 
 - **Claude**: if `~/.claude` exists on the host, it is bind-mounted into the container for OAuth session persistence.
 - **Codex**: if `~/.codex` exists on the host, it is bind-mounted into the container for OAuth/cached login persistence.
-- **Cursor**: if `~/.cursor` exists on the host, it is bind-mounted into the container so `cursor-agent` has access to its project state and config.
+- **Cursor**: if `~/.cursor` exists on the host, it is bind-mounted into the container so `cursor-agent` has access to its project state and config. `~/.config/cursor/` is also bind-mounted read-write for auth and configuration persistence.
 
 ## Command Blocking (BPF LSM)
 

--- a/ai-sandbox
+++ b/ai-sandbox
@@ -186,8 +186,8 @@ if [[ -z "${!API_KEY_VAR:-}" ]]; then
         echo -e "${CYAN}Using OAuth session from ~/.claude${NC}"
     elif [[ "$AGENT" == "codex" && -d "${HOME}/.codex" ]]; then
         echo -e "${CYAN}Using cached login from ~/.codex${NC}"
-    elif [[ "$AGENT" == "cursor" && -f "${HOME}/.config/cursor/auth.json" ]]; then
-        echo -e "${CYAN}Using JWT auth from ~/.config/cursor/auth.json${NC}"
+    elif [[ "$AGENT" == "cursor" && -d "${HOME}/.config/cursor" ]]; then
+        echo -e "${CYAN}Using config from ~/.config/cursor/${NC}"
     else
         echo -e "${YELLOW}Warning: ${API_KEY_VAR} not set.${NC}"
         echo "Set it with: export ${API_KEY_VAR}=<your-key>"
@@ -286,9 +286,9 @@ if [[ "$AGENT" == "cursor" ]]; then
     if [[ -d "${HOME}/.cursor" ]]; then
         CMD+=(-v "${HOME}/.cursor:/home/agent/.cursor:Z")
     fi
-    # auth.json: ro (contains JWT tokens, no need to write)
-    if [[ -f "${HOME}/.config/cursor/auth.json" ]]; then
-        CMD+=(-v "${HOME}/.config/cursor/auth.json:/home/agent/.config/cursor/auth.json:ro,Z")
+    # ~/.config/cursor: rw (auth.json, config, etc.)
+    if [[ -d "${HOME}/.config/cursor" ]]; then
+        CMD+=(-v "${HOME}/.config/cursor:/home/agent/.config/cursor:Z")
     fi
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -166,6 +166,21 @@ install_build_data() {
     log "Build data installed successfully"
 }
 
+# --- Ensure host directories for agent configs exist -------------------------
+ensure_host_dirs() {
+    local cursor_config="${HOME}/.config/cursor"
+    if [[ ! -d "$cursor_config" ]]; then
+        log "Creating ${cursor_config}/"
+        install -d "$cursor_config"
+    fi
+
+    local cursor_dot="${HOME}/.cursor"
+    if [[ ! -d "$cursor_dot" ]]; then
+        log "Creating ${cursor_dot}/"
+        install -d "$cursor_dot"
+    fi
+}
+
 # --- Build container images ---------------------------------------------------
 build_images() {
     log "Building container images (this may take a few minutes)..."
@@ -466,6 +481,7 @@ check_prerequisites
 # 2. Install the main script and build data
 install_script
 install_build_data
+ensure_host_dirs
 echo ""
 
 # 3. Build container images (unless --no-build)


### PR DESCRIPTION
- ai-sandbox: mount the entire ~/.config/cursor/ directory read-write instead of the single auth.json file read-only
- install.sh: create ~/.config/cursor/ and ~/.cursor/ on the host if they don't exist, so bind mounts work on first run
- Update README to reflect the new mount behavior