### PR TITLE
reduce base image size from ~1.64 GB to ~1.44 GB

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,9 @@ Installed via the official `cursor.com/install` script. The installation is copi
 
 ## Base Image
 
-Built on **Fedora 43** and includes: Node.js, npm, Python 3.14 (default), Python 3.13, Python 3.12 (each with devel and libs — ready for `python3.XX -m venv`), pytest, ruff, Git, curl, wget, ripgrep, fd-find, jq, yq, tree, Ansible, ansible-lint, ShellCheck, OpenShift client (`oc`), strace, poppler-utils (pdfinfo, pdftotext, pdfimages, etc.), mupdf (mutool), binutils (strings, objdump, nm, readelf, etc. — `as` and `ld` are removed for hardening), and standard GNU utilities (sed, gawk, grep, findutils, diffutils, patch, tar, gzip, unzip).
+Built on **Fedora 43** and includes: Node.js, npm, Python 3.14 (default), Python 3.13, Python 3.12 (each with devel and libs — ready for `python3.XX -m venv`), pytest, ruff, Git, curl, wget, ripgrep, fd-find, jq, yq, tree, Ansible, ansible-lint, ShellCheck, OpenShift client (`oc`), strace, poppler-utils (pdfinfo, pdftotext, pdfimages, etc.), mupdf (mutool — GUI binaries removed), binutils (strings, objdump, nm, readelf, etc. — `as` and `ld` are removed for hardening), and standard GNU utilities (sed, gawk, grep, findutils, diffutils, patch, tar, gzip, unzip).
+
+The image is size-optimised: weak dependencies are skipped (`install_weak_deps=False`), documentation is excluded (`tsflags=nodocs`), mupdf's unused GUI dependencies (mesa, llvm-libs, X11) are removed after install, ELF binaries are stripped, and everything runs in a single layer.
 
 ## Notes
 

--- a/base/Containerfile
+++ b/base/Containerfile
@@ -10,10 +10,18 @@ LABEL maintainer="amedeo" \
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Common toolchain for all agents
+# Size optimisations (base Fedora ≈200 MB → final layer ≈1.2 GB):
+#   --setopt=install_weak_deps=False  skip Recommends/Suggests
+#   --setopt=tsflags=nodocs           skip man pages and documentation
+#   rpm -e --nodeps …                 remove mupdf GUI deps (mesa/llvm/X11) unused by mutool
+#   strip --strip-unneeded            remove debug symbols from ELF binaries
+#   rm -rf …/doc,man,info,locale      remove residual documentation
 RUN dnf install -y \
+        --setopt=install_weak_deps=False \
+        --setopt=tsflags=nodocs \
         nodejs \
         npm \
-        git \
+        git-core \
         python3 \
         python3-pip \
         python3.12 \
@@ -52,13 +60,22 @@ RUN dnf install -y \
         poppler-utils \
         mupdf \
     && rm -f /usr/bin/as /usr/bin/ld /usr/bin/ld.bfd \
+    && rm -f /usr/bin/mupdf /usr/bin/mupdf-gl /usr/bin/mupdf-x11 \
+    && rpm -e --nodeps \
+        llvm-libs llvm-filesystem \
+        mesa-dri-drivers mesa-libGL mesa-libgbm mesa-filesystem \
+        hwdata \
+        freeglut libglvnd libglvnd-opengl libglvnd-glx \
+        libX11 libX11-common libX11-xcb libXau libXext libXi libXrender libXxf86vm \
+        libxcb libxshmfence \
+        2>/dev/null || true \
+    && curl -fsSL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz \
+        | tar xz -C /usr/local/bin oc kubectl \
+    && chmod 755 /usr/local/bin/oc /usr/local/bin/kubectl \
     && dnf clean all \
-    && rm -rf /var/cache/dnf
-
-# OpenShift client (oc) - latest stable from mirror.openshift.com
-RUN curl -fsSL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz \
-    | tar xz -C /usr/local/bin oc kubectl \
-    && chmod 755 /usr/local/bin/oc /usr/local/bin/kubectl
+    && rm -rf /var/cache/dnf /usr/share/doc /usr/share/man /usr/share/info /usr/share/locale \
+    && find /usr -type f \( -name '*.so*' -o -perm /111 \) -exec strip --strip-unneeded {} + 2>/dev/null || true \
+    && rm -rf /usr/lib/.build-id
 
 # Non-root user for agent execution
 RUN useradd -m -s /bin/bash agent


### PR DESCRIPTION
Skip weak deps and docs at install time, remove mupdf's GUI-only dependencies (mesa, llvm-libs, X11/GL) that are unused by mutool, strip debug symbols from ELF binaries, and merge all build steps into a single layer.