### PR TITLE
configurable CPU and memory limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Every container is launched with the following hardening measures:
 | `--no-new-privileges`         | Prevents privilege escalation (setuid, etc.)               |
 | `--read-only`                 | Container filesystem is read-only                          |
 | `--pids-limit=512`            | Prevents fork bombs                                        |
-| `--cpus=2 --memory=4g`        | Limits CPU and RAM resources via cgroups v2                |
+| `--cpus` / `--memory`         | Limits CPU and RAM via cgroups v2 (default 2 CPU / 4g, see [Resource Limits](#resource-limits)) |
 | `--network=pasta`             | Kernel-backed isolated network (fast, uses user namespaces)|
 | `--tmpfs /tmp`                | Temporary writable area, destroyed at session end          |
 | `--mount type=tmpfs,dst=/home/agent` | Agent home on tmpfs (mode 0755), destroyed at session end |
@@ -122,6 +122,8 @@ Options:
   -b, --block-cmd <b:a>   Block command inside container (repeatable, e.g. "git:push")
   -n, --network-off       Disable network completely (--network=none)
   -d, --dns <server>      DNS server (default: 1.1.1.1, env: AI_SANDBOX_DNS)
+      --cpus <n>           CPU limit (default: 2, env: AI_SANDBOX_CPUS)
+      --memory <size>      RAM limit (default: 4g, env: AI_SANDBOX_MEMORY)
       --home-size <size>   Size of /home/agent tmpfs (default: 1g, units: b, k, m, g)
       --build [target]     Build container images (all|base|claude|codex|cursor|opencode)
   -v, --verbose           Show the podman command being run
@@ -133,13 +135,37 @@ Options for opencode:
       --no-api-key        Do not require AI_SANDBOX_OPENCODE_API_KEY (endpoints that ignore it)
 ```
 
+## Resource Limits
+
+CPU and RAM can be raised per run:
+
+```bash
+ai-sandbox claude --cpus 12 --memory 24g
+```
+
+Or persistently, in `~/.config/ai-sandbox/env`:
+
+```bash
+AI_SANDBOX_CPUS=12
+AI_SANDBOX_MEMORY=24g
+```
+
+Precedence is: command-line flag > `~/.config/ai-sandbox/env` (or shell environment) > built-in
+default (2 CPU, 4g).
+
+The memory limit is always enforced. The CPU limit requires CFS bandwidth control in the kernel
+(`CONFIG_CFS_BANDWIDTH=y`, which provides `cpu.max`) and, for rootless podman, the `cpu` controller
+delegated to your user cgroup. When either is missing, `ai-sandbox` skips `--cpus` instead of
+failing to start: the startup banner then reports `CPU unlimited (no cgroup quota)`, and an
+explicit `--cpus` prints a warning.
+
 ## Customization
 
 Edit the variables at the top of the `ai-sandbox` script:
 
 ```bash
-MAX_CPUS="2"           # Number of CPUs
-MAX_MEM="4g"           # RAM limit
+MAX_CPUS_DEFAULT="2"   # Number of CPUs (override with --cpus / AI_SANDBOX_CPUS)
+MAX_MEM_DEFAULT="4g"   # RAM limit (override with --memory / AI_SANDBOX_MEMORY)
 MAX_PIDS="512"         # Process limit
 TMPFS_TMP_SIZE="1g"    # /tmp size
 TMPFS_HOME_SIZE="1g"   # /home/agent size (units: b, k, m, g)

--- a/ai-sandbox
+++ b/ai-sandbox
@@ -39,6 +39,11 @@
 #   CURSOR_API_KEY=...
 #   AI_SANDBOX_OPENCODE_API_KEY=...
 #
+# Resource limits can be set there as well:
+#   AI_SANDBOX_CPUS=12
+#   AI_SANDBOX_MEMORY=24g
+# and overridden per run with --cpus / --memory.
+#
 # For opencode, the endpoint and model can also be set there:
 #   AI_SANDBOX_OPENCODE_BASE_URL=https://ollama.com/v1
 #   AI_SANDBOX_OPENCODE_MODEL=glm-5.2:cloud
@@ -48,8 +53,8 @@ set -euo pipefail
 
 # --- Configuration ------------------------------------------------------------
 BUILDER="podman"
-MAX_CPUS="2"
-MAX_MEM="4g"
+MAX_CPUS_DEFAULT="2"           # override with --cpus or AI_SANDBOX_CPUS
+MAX_MEM_DEFAULT="4g"           # override with --memory or AI_SANDBOX_MEMORY
 MAX_PIDS="512"
 TMPFS_TMP_SIZE="1g"
 TMPFS_HOME_SIZE="1g"
@@ -77,6 +82,28 @@ validate_size() {
     fi
 }
 
+validate_cpus() {
+    local value="$1"
+    if [[ ! "$value" =~ ^[0-9]+(\.[0-9]+)?$ ]] || [[ "$value" =~ ^0+(\.0+)?$ ]]; then
+        echo -e "${RED}Error: invalid CPU count '${value}'.${NC}" >&2
+        echo "Use a positive number, e.g. 2, 4, 12, or a fraction like 1.5" >&2
+        exit 1
+    fi
+}
+
+# podman's --cpus needs CFS bandwidth control (CONFIG_CFS_BANDWIDTH=y), which is what
+# creates cpu.max in a cgroup v2 hierarchy. Rootless additionally needs the 'cpu'
+# controller delegated to the user's cgroup, otherwise crun fails to apply the limit.
+cpu_quota_supported() {
+    local rel base
+    rel="$(awk -F: '$1 == "0" { print $3; exit }' /proc/self/cgroup 2>/dev/null)"
+    [[ -n "$rel" ]] || return 1
+    base="/sys/fs/cgroup${rel}"
+    [[ -f "${base}/cpu.max" ]] || return 1
+    grep -qw cpu "${base}/cgroup.controllers" 2>/dev/null || \
+        grep -qw cpu "$(dirname "${base}")/cgroup.controllers" 2>/dev/null
+}
+
 usage() {
     echo -e "${CYAN}ai-sandbox${NC} - Starts an AI agent in a sandboxed container"
     echo ""
@@ -94,6 +121,8 @@ usage() {
     echo "  -b, --block-cmd <b:a>   Block command inside container (repeatable, e.g. \"git:push\")"
     echo "  -n, --network-off       Disable network (no API, local only)"
     echo "  -d, --dns <server>      DNS server (default: 1.1.1.1, env: AI_SANDBOX_DNS)"
+    echo "      --cpus <n>          CPU limit (default: ${MAX_CPUS_DEFAULT}, env: AI_SANDBOX_CPUS)"
+    echo "      --memory <size>     RAM limit (default: ${MAX_MEM_DEFAULT}, env: AI_SANDBOX_MEMORY)"
     echo "      --home-size <size>  Size of /home/agent tmpfs (default: ${TMPFS_HOME_SIZE})"
     echo "                          Units: b (bytes), k (kilobytes), m (megabytes), g (gigabytes)"
     echo "      --build [target]    Build container images (all|base|claude|codex|cursor|opencode)"
@@ -117,6 +146,8 @@ BLOCK_CMDS=()
 OPT_MODEL=""
 OPT_BASE_URL=""
 OPT_NO_API_KEY=false
+OPT_CPUS=""
+OPT_MEMORY=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -137,6 +168,8 @@ while [[ $# -gt 0 ]]; do
         --home-size)  TMPFS_HOME_SIZE="$2"; shift 2 ;;
         # Kept in OPT_* until after the env file is sourced, otherwise
         # 'source' would silently overwrite them (see the resolution block below).
+        --cpus)       OPT_CPUS="$2"; shift 2 ;;
+        --memory)     OPT_MEMORY="$2"; shift 2 ;;
         --model)      OPT_MODEL="$2"; shift 2 ;;
         --base-url)   OPT_BASE_URL="$2"; shift 2 ;;
         --no-api-key) OPT_NO_API_KEY=true; shift ;;
@@ -238,10 +271,16 @@ if [[ -f "$ENV_FILE" ]]; then
     set +a
 fi
 
-# --- Resolve opencode settings ------------------------------------------------
+# --- Resolve resource limits --------------------------------------------------
 # Precedence: CLI flag > env file > shell environment > built-in default.
 # The env file is sourced above with 'set -a', which overwrites variables already
 # exported in the shell, so the CLI overrides must be applied here — after it.
+MAX_CPUS="${OPT_CPUS:-${AI_SANDBOX_CPUS:-$MAX_CPUS_DEFAULT}}"
+MAX_MEM="${OPT_MEMORY:-${AI_SANDBOX_MEMORY:-$MAX_MEM_DEFAULT}}"
+validate_cpus "$MAX_CPUS"
+validate_size "$MAX_MEM"
+
+# --- Resolve opencode settings ------------------------------------------------
 if [[ "$AGENT" == "opencode" ]]; then
     if [[ -n "$OPT_MODEL" ]]; then
         AI_SANDBOX_OPENCODE_MODEL="$OPT_MODEL"
@@ -349,10 +388,7 @@ CMD=(
     --pids-limit="${MAX_PIDS}"              # Prevent fork bombs
 
     # === RESOURCES ===
-    # NOTE: --cpus requires CONFIG_CFS_BANDWIDTH=y in the kernel.
-    # If your kernel lacks it, cpu.max won't exist and crun will fail.
-    # Uncomment the next line if your kernel supports CFS bandwidth:
-    # --cpus="${MAX_CPUS}"
+    # --cpus is appended below, only when the kernel/cgroup supports CPU quotas.
     --memory="${MAX_MEM}"
 
     # === FILESYSTEM ===
@@ -369,6 +405,16 @@ CMD=(
     # === NETWORK ===
     # slirp4netns: userspace network stack, isolated from host
 )
+
+# === CPU QUOTA ===
+CPU_LIMIT_APPLIED=false
+if cpu_quota_supported; then
+    CMD+=(--cpus="${MAX_CPUS}")
+    CPU_LIMIT_APPLIED=true
+elif [[ -n "$OPT_CPUS" || -n "${AI_SANDBOX_CPUS:-}" ]]; then
+    echo -e "${YELLOW}Warning: no CPU quota support (cpu.max missing or 'cpu' not delegated to this cgroup).${NC}" >&2
+    echo -e "${YELLOW}         --cpus=${MAX_CPUS} ignored; the container can use all host CPUs.${NC}" >&2
+fi
 
 if [[ "$NETWORK_OFF" == true ]]; then
     CMD+=(--network=none)
@@ -482,7 +528,11 @@ fi
 
 echo -e "${GREEN}Starting ${AGENT} in sandbox${NC} (${PROJECT_DIR})"
 echo -e "  Container: ${CONTAINER_NAME}"
-echo -e "  Resources: ${MAX_CPUS} CPU, ${MAX_MEM} RAM, ${MAX_PIDS} PIDs max"
+if [[ "$CPU_LIMIT_APPLIED" == true ]]; then
+    echo -e "  Resources: ${MAX_CPUS} CPU, ${MAX_MEM} RAM, ${MAX_PIDS} PIDs max"
+else
+    echo -e "  Resources: CPU unlimited (no cgroup quota), ${MAX_MEM} RAM, ${MAX_PIDS} PIDs max"
+fi
 echo -e "  Home size: ${TMPFS_HOME_SIZE}"
 echo -e "  Network:   $("${NETWORK_OFF}" && echo 'DISABLED' || echo "${NETWORK_MODE} (dns: ${DNS})")"
 if [[ "$AGENT" == "opencode" ]]; then


### PR DESCRIPTION
The limits were hardcoded at the top of the script, so raising them meant editing the installed copy. Add --cpus <n> and --memory <size>, settable per run or persistently via AI_SANDBOX_CPUS / AI_SANDBOX_MEMORY in the env file. Flags are held in OPT_* and resolved after the env file is sourced, since 'set -a; source' would otherwise overwrite them; precedence is flag > env file
> shell > default, matching the opencode settings.

--cpus was commented out inside the CMD array, so it never reached podman: containers had no CPU limit at all, while the banner and the README security table both claimed 2 CPU. The comment explained why — --cpus needs CONFIG_CFS_BANDWIDTH=y, and without it cpu.max does not exist and crun fails. Rather than leaving it disabled, probe for support at runtime: cpu_quota_supported() checks that cpu.max exists in the current cgroup and that the cpu controller is delegated, which rootless podman also requires. When it is missing the flag is skipped instead of failing to start, the banner says "CPU unlimited (no cgroup quota)", and an explicit --cpus warns.

Note the behaviour change: defaults stay 2 CPU / 4g, but the CPU default is now actually enforced where the kernel supports it.

--memory also routes through the existing validate_size(); it was previously unvalidated. validate_cpus() is its sibling, accepting podman's fractional values and rejecting zero.

Verified: shellcheck, the four precedence combinations, invalid-input rejection, command construction against a podman stub, and the degraded path with the probe forced to fail. Not verified end to end — the sandbox running this had neither podman nor sudo, so no container was started to read cpu.max/memory.max from the inside, and the --block-cmd path was not exercised (--cpus survives into CMD_BG by construction, which strips only --rm/-it/-i/-t).


Claude-Session: https://claude.ai/code/session_018Nf92cijQM2A77k96GQ9wq